### PR TITLE
Add basic Node client portal example

### DIFF
--- a/BNBClientPortal/README.md
+++ b/BNBClientPortal/README.md
@@ -1,0 +1,31 @@
+# BNB Client Portal
+
+Ce dossier contient un exemple minimal d'application Node.js utilisant **Express** et **Stripe** pour permettre aux clients de BNB de consulter leurs contrats, acheter des contrats de maintenance et recevoir leur facture.
+
+## Prérequis
+- Node.js >= 18
+- Une clef `STRIPE_SECRET_KEY` valide
+- Optionnel : `STRIPE_ENDPOINT_SECRET` pour sécuriser le webhook
+
+## Installation
+1. Dans ce dossier, installez les dépendances :
+   ```bash
+   npm install express stripe
+   ```
+2. Définissez vos variables d'environnement :
+   ```bash
+   export STRIPE_SECRET_KEY=sk_test_...
+   export STRIPE_ENDPOINT_SECRET=whsec_...
+   ```
+
+## Utilisation
+Lancez l'application :
+```bash
+node server.js
+```
+
+- `GET /contracts` renvoie la liste des contrats (exemple statique ici).
+- `POST /purchase-maintenance` crée une session de paiement Stripe pour l'achat d'un contrat de maintenance.
+- `POST /webhook` reçoit les évènements Stripe comme la confirmation de paiement de facture.
+
+Cet exemple se veut simple et pédagogique. Il faudra l'adapter (authentification, base de données, interface utilisateur) pour un portail client complet.

--- a/BNBClientPortal/package.json
+++ b/BNBClientPortal/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "bnbclientportal",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/BNBClientPortal/server.js
+++ b/BNBClientPortal/server.js
@@ -1,0 +1,66 @@
+const express = require('express');
+const Stripe = require('stripe');
+
+const app = express();
+const stripe = Stripe(process.env.STRIPE_SECRET_KEY);
+
+app.use(express.json());
+
+// Example contracts data
+const contracts = [
+  { id: 1, name: 'Contrat de base', status: 'actif' },
+  { id: 2, name: 'Contrat premium', status: 'expire' }
+];
+
+app.get('/contracts', (req, res) => {
+  // In real implementation, fetch user contracts from database
+  res.json(contracts);
+});
+
+app.post('/purchase-maintenance', async (req, res) => {
+  try {
+    // Create a Stripe Checkout session for a maintenance contract
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ['card'],
+      line_items: [
+        {
+          price_data: {
+            currency: 'eur',
+            product_data: { name: 'Contrat de maintenance' },
+            unit_amount: 5000 // 50 EUR
+          },
+          quantity: 1
+        }
+      ],
+      mode: 'payment',
+      success_url: 'https://example.com/success',
+      cancel_url: 'https://example.com/cancel'
+    });
+    res.json({ id: session.id });
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Erreur creation session Stripe');
+  }
+});
+
+app.post('/webhook', express.raw({ type: 'application/json' }), (req, res) => {
+  const sig = req.headers['stripe-signature'];
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(req.body, sig, process.env.STRIPE_ENDPOINT_SECRET);
+  } catch (err) {
+    console.error(err);
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+  // Handle invoice.paid event, etc
+  if (event.type === 'invoice.paid') {
+    const invoice = event.data.object;
+    console.log('Invoice paid:', invoice.id);
+  }
+  res.json({ received: true });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Serveur BNB Client Portal lancé sur le port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a `BNBClientPortal` example folder
- show how to set up Express and Stripe for a client portal

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684c2de3f204832e886f72c28ba81503